### PR TITLE
nozzle: Provide nozzle cooling by a print fan

### DIFF
--- a/lib/Marlin/Marlin/src/Marlin.cpp
+++ b/lib/Marlin/Marlin/src/Marlin.cpp
@@ -656,6 +656,7 @@ void idle(
   );
 
   thermalManager.manage_heater();
+  thermalManager.check_and_reset_fan_speeds();
 
   #if ENABLED(PRINTCOUNTER)
     print_job_timer.tick();

--- a/lib/Marlin/Marlin/src/gcode/temperature/M104_M109.cpp
+++ b/lib/Marlin/Marlin/src/gcode/temperature/M104_M109.cpp
@@ -64,6 +64,10 @@ void GcodeSuite::M104() {
       if (target_extruder != active_extruder) return;
     #endif
     thermalManager.setTargetHotend(temp, target_extruder);
+    if (parser.seen('C') && thermalManager.isCoolingHotend(target_extruder))
+      thermalManager.start_nozzle_cooling(target_extruder);
+    else
+      thermalManager.reset_fan_speed(target_extruder);
 
     #if ENABLED(DUAL_X_CARRIAGE)
       if (dxc_is_duplicating() && target_extruder == 0)
@@ -147,8 +151,12 @@ void GcodeSuite::M109() {
     planner.autotemp_M104_M109();
   #endif
 
-  if (set_temp)
-    (void)thermalManager.wait_for_hotend(target_extruder, no_wait_for_cooling);
+  if (set_temp) {
+    #if ENABLED(PRUSA_MARLIN_API)
+      marlin_server_set_temp_to_display(parser.seenval('D') ? parser.value_celsius() : thermalManager.degTargetHotend(target_extruder));
+    #endif
+    (void)thermalManager.wait_for_hotend(target_extruder, no_wait_for_cooling, parser.seen('C'));
+  }
 }
 
 #endif // EXTRUDERS

--- a/lib/Marlin/Marlin/src/module/temperature.h
+++ b/lib/Marlin/Marlin/src/module/temperature.h
@@ -25,6 +25,7 @@
  * temperature.h - temperature controller
  */
 
+#include <optional>
 #include "thermistor/thermistors.h"
 
 #include "../inc/MarlinConfig.h"
@@ -419,6 +420,8 @@ class Temperature {
       static bool paused;
     #endif
 
+    static std::optional<uint8_t> previous_fan_speed[EXTRUDERS];
+
   public:
     #if HAS_ADC_BUTTONS
       static uint32_t current_ADCKey_raw;
@@ -490,6 +493,21 @@ class Temperature {
       #define FANS_LOOP(I) LOOP_L_N(I, FAN_COUNT)
 
       static void set_fan_speed(const uint8_t target, const uint16_t speed);
+      
+      /**
+       * Save current fan speed and turns fan to full blast for fast nozzle cooling
+       */
+      static void start_nozzle_cooling(const uint8_t target);
+      
+      /**
+       * Set fan speed to previous speed if fan was used for cooling the nozzle
+       */
+      static void reset_fan_speed(const uint8_t target);
+      
+      /**
+       * Reset fans if temperature is low enough
+       */
+      static void check_and_reset_fan_speeds();
 
       #if EITHER(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
         static bool fans_paused;
@@ -727,6 +745,9 @@ private:
      * used by disable_all_heaters and disable_hotend
      */
     static void disable_heaters(disable_bed_t disable_bed);
+
+    static void set_fan_speed_(const uint8_t target, const uint16_t speed);
+
 public:
     /**
      * Switch off all heaters, set all target temperatures to 0


### PR DESCRIPTION
If nozzle is set to lower temperature (e.g. before G29) fan can be activated to speed up cooling.